### PR TITLE
Fix syntax error for `git log`command

### DIFF
--- a/3.md
+++ b/3.md
@@ -15,7 +15,7 @@ Efter denne uges undervisning, læsning og øvelser kan du:
 	* git add <filename>: adds files to staging area
 	* git commit: creates a new commit
 	* git log: shows a flattened log of history
-	* git log ---all ---graph ---decorate: visualizes history as a DAG
+	* git log --all --graph --decorate=no: visualizes history as a DAG
 	* git checkout <revision>: updates HEAD and current branch
 	* git clone: download repository from remote
 


### PR DESCRIPTION
Fixes the `git log` command using too many dashes for the flags
Fixes the `--decorate` missing an option (=short, full, auto, no)
:^)